### PR TITLE
* 修改组为github

### DIFF
--- a/build-config.gradle
+++ b/build-config.gradle
@@ -1,5 +1,5 @@
 //子项目公有配置类
-group 'com.ejiahe.plugins'
+group 'io.github.jiami'
 version = "1.0.0"
 
 tasks.withType(JavaCompile) {

--- a/jm-builder/build.gradle
+++ b/jm-builder/build.gradle
@@ -15,7 +15,7 @@ artifacts {
 gradlePlugin {
     plugins {
         greetingsPlugin {
-            id = 'com.ejiahe.plugin-builder' //插件的id
+            id = 'io.github.jiami.builder' //插件的id
             implementationClass = 'com.ejiahe.gradle.plugin.builder.BuilderPlugin'
         }
     }

--- a/jm-optional/build.gradle
+++ b/jm-optional/build.gradle
@@ -15,7 +15,7 @@ artifacts {
 gradlePlugin {
     plugins {
         greetingsPlugin {
-            id = 'com.ejiahe.plugin-optional' //插件的id
+            id = 'io.github.jiami.optional' //插件的id
             implementationClass = 'com.ejiahe.gradle.plugin.optional.OptionalPlugin'
         }
     }

--- a/jm-publisher/build.gradle
+++ b/jm-publisher/build.gradle
@@ -15,7 +15,7 @@ artifacts {
 gradlePlugin {
     plugins {
         greetingsPlugin {
-            id = 'com.ejiahe.plugin-publisher' //插件的id
+            id = 'io.github.jiami.publisher' //插件的id
             implementationClass = 'com.ejiahe.gradle.plugin.publisher.PublisherPlugin'
         }
     }

--- a/jm-structure/build.gradle
+++ b/jm-structure/build.gradle
@@ -15,7 +15,7 @@ artifacts {
 gradlePlugin {
     plugins {
         greetingsPlugin {
-            id = 'com.ejiahe.plugin-structure' //插件的id
+            id = 'io.github.jiami.structure' //插件的id
             implementationClass = 'com.ejiahe.gradle.plugin.structure.StructurePlugin'
         }
     }


### PR DESCRIPTION
* 插件 ID 应该追溯到作者
如果 GitHub 用户johndoe发布了一个名为 的插件myplugin，那么可接受的插件 ID 将为io.github.johndoe.myplugin. 注意：com.github不再接受作为前缀，以便与Maven Central policy保持一致 。

另一个例子是公司插件，比方说来自mybusiness.com；那么插件 ID 应该看起来像com.mybusiness.pluginname. 在这种情况下，作者还应通过公司帐户/电子邮件地址提交插件。我们更喜欢组（而不是个人）地址，以强调组织（或其子组）是插件的所有者。

如果我们无法链接到域，我们将要求提供证明，将 TXT 记录添加到 DNS 条目中。